### PR TITLE
14.04 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.deb
+Dockerfile-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV LD_LIBRARY_PATH /usr/local/lib/mcrouter/
 RUN mkdir /tmp/mcrouter-build && ./scripts/install_ubuntu_${UBUNTU_RELEASE}.sh /tmp/mcrouter-build
 
 # Install Ruby so we can install fpm for building the Debian package
-RUN apt-get install -y python-software-properties
+RUN apt-get install -y software-properties-common
 RUN add-apt-repository ppa:brightbox/ruby-ng
 RUN apt-get -y update && apt-get -y install ruby2.1 ruby2.1-dev
 RUN echo "gem: --no-ri --no-rdoc" > ~/.gemrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM ubuntu:12.04
+FROM ubuntu:__UBUNTU_RELEASE__
 MAINTAINER Brian Morton "bmorton@yammer-inc.com"
 
-ENV MCROUTER_VERSION 0.15
-ENV MCROUTER_SHA f1f40cc225a56369f14d3b5f39ef5d4f122dda3f
+ENV MCROUTER_VERSION __MCROUTER_VERSION__
+ENV MCROUTER_SHA __MCROUTER_SHA__
+ENV UBUNTU_RELEASE __UBUNTU_RELEASE__
 
 # Install tools needed by install scripts below
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
@@ -16,9 +17,10 @@ RUN curl -L https://github.com/facebook/mcrouter/archive/${MCROUTER_SHA}.tar.gz 
 WORKDIR /tmp/mcrouter-${MCROUTER_SHA}/mcrouter
 ENV LDFLAGS -Wl,-rpath=/usr/local/lib/mcrouter/
 ENV LD_LIBRARY_PATH /usr/local/lib/mcrouter/
-RUN mkdir /tmp/mcrouter-build && ./scripts/install_ubuntu_12.04.sh /tmp/mcrouter-build
+RUN mkdir /tmp/mcrouter-build && ./scripts/install_ubuntu_${UBUNTU_RELEASE}.sh /tmp/mcrouter-build
 
 # Install Ruby so we can install fpm for building the Debian package
+RUN apt-get install -y python-software-properties
 RUN add-apt-repository ppa:brightbox/ruby-ng
 RUN apt-get -y update && apt-get -y install ruby2.1 ruby2.1-dev
 RUN echo "gem: --no-ri --no-rdoc" > ~/.gemrc

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ cp:
 	docker create --name=mcrouter-build mcrouter && docker cp mcrouter-build:/tmp/mcrouter-build/install/yammer-mcrouter_${MCROUTER_VERSION}-${MCROUTER_SHA}_amd64.deb . && docker rm -f mcrouter-build
 
 test:
-	docker run -ti --rm -v `pwd`:/opt/mcrouter-build ubuntu:12.04 sh -c "dpkg -i /opt/mcrouter-build/yammer-mcrouter_${MCROUTER_VERSION}-${MCROUTER_SHA}_amd64.deb; mcrouter --version; /bin/bash"
+	docker run -ti --rm -v `pwd`:/opt/mcrouter-build ubuntu:${UBUNTU_RELEASE} sh -c "dpkg -i /opt/mcrouter-build/yammer-mcrouter_${MCROUTER_VERSION}-${MCROUTER_SHA}_amd64.deb; mcrouter --version; /bin/bash"
 
 clean:
 		rm -f Dockerfile-*

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 UBUNTU_RELEASE = "14.04"
 MCROUTER_VERSION = $(shell git ls-remote --tags https://github.com/facebook/mcrouter.git | sort -t '/' -k 3 -V | tail -n1 | awk '{print $$1}')
 MCROUTER_SHA = $(shell git ls-remote --tags https://github.com/facebook/mcrouter.git | sort -t '/' -k 3 -V | tail -n1 | awk '{print $$2}' | awk -F\/ '{print $$3}')
-MCROUTER_SHA = "bbc2a529cd5f2a5796e4d2fadecf4db86a9ac7be"
 
 .PHONY: all build cp
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mcrouter package builder
 
-This `Dockerfile` will create a `.deb` package for [mcrouter](https://github.com/facebook/mcrouter) for use on Ubuntu 12.04.  Yammer uses this package to deploy mcrouter to its production environments.
+This `Dockerfile` will create a `.deb` package for [mcrouter](https://github.com/facebook/mcrouter) for use on Ubuntu 12.04 or 14.04.  Yammer uses this package to deploy mcrouter to its production environments.
 
 
 ## Building
@@ -10,12 +10,12 @@ To build and copy the package to your local filesystem, run `make`.
 
 ## Testing package
 
-To start up a new 12.04 Docker container with the built package installed, run `make test`.
+To start up a new 12.04 or 14.04 Docker container with the built package installed, edit
+the `UBUNTU_RELEASE` variable at the top of the Makefile and run `make test`.
 
 
 ## Updating
 
 For updating to a new version of mcrouter, update the `MCROUTER_VERSION` and
-`MCROUTER_SHA` environment variables in the `Dockerfile`.  You'll probably have
-to update the `FOLLY_SHA` variable as well since mcrouter usually depends on the
-latest version of Folly.
+`MCROUTER_SHA` environment variables in the `Dockerfile`. This will default to the latest
+release tag, but you can replace that with a specific commit hash if you need to.


### PR DESCRIPTION
So I finally had some time to work on this.  I'm not sure what your thoughts are on this but since upstream mcrouter has started adding `FOLLY_COMMIT` files, this is all much easier.

This PR is an attempt to accomplish two things:

1)  Add support for 14.04 without breaking 12.04 support or making too many changes
2)  Try to automate the builds further by pulling down the Mcrouter version and commit hash automatically.  This is so that the builds could be setup via cron if desired, without having to manually add the newest SHA hash.

Currently, there is a problem upstream.  The 0.15.0 (newest release as of now) does not contain the `FOLLY_COMMIT` file.  The correct SHA with that file is actually https://github.com/facebook/mcrouter/commit/bbc2a529cd5f2a5796e4d2fadecf4db86a9ac7be

So I would suggest that we wait for their next release and do some testing then when considering merging this in or not.
